### PR TITLE
[cleanup] Make the project build on macOS and Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,25 @@
 # Versão mínima do CMake
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.28)
 
 # Nome do projeto
-project(Sapphire)
+project(Sapphire LANGUAGES CXX)
+
+include(FetchContent)
+FetchContent_Declare(SFML
+        GIT_REPOSITORY https://github.com/SFML/SFML.git
+        GIT_TAG 3.0.2
+        GIT_SHALLOW ON
+        EXCLUDE_FROM_ALL
+        SYSTEM)
+FetchContent_MakeAvailable(SFML)
+
+FetchContent_Declare(httplib
+        GIT_REPOSITORY https://github.com/yhirose/cpp-httplib.git
+        GIT_TAG v0.29.0
+        GIT_SHALLOW ON
+        EXCLUDE_FROM_ALL
+        SYSTEM)
+FetchContent_MakeAvailable(httplib)
 
 # Define o padrão do C++ para C++17
 set(CMAKE_CXX_STANDARD 17)
@@ -14,16 +31,22 @@ set(EXECUTABLE_NAME sapphire)
 # Adiciona uma definição para ativar o código de depuração
 add_compile_definitions(DEBUG_PRINT_CODE)
 
-# Lista todos os arquivos-fonte (.cpp) que compõem o projeto
+# Lista todxos os arquivos-fonte (.cpp) que compõem o projeto
+FILE(GLOB SOURCES src/*.cpp)
 set(SOURCES
-    src/main.cpp
-    src/lexer.cpp
-    src/compiler.cpp
-    src/parser.cpp
-    src/object.cpp
-    src/vm.cpp
-    src/value.cpp
-    src/debug.cpp # <<< ADICIONE ESTA LINHA
+        # keep-sorted start
+        src/main.cpp
+        src/utils.cpp
+        src/bytecode_io.cpp
+        src/lexer.cpp
+        src/compiler.cpp
+        src/parser.cpp
+        src/sfml_graphics_natives.cpp
+        src/object.cpp
+        src/vm.cpp
+        src/value.cpp
+        src/debug.cpp # <<< ADICIONE ESTA LINHA
+        # keep-sorted end
 )
 
 # Lista os diretórios onde os arquivos de cabeçalho (.h) estão
@@ -32,4 +55,7 @@ include_directories(src)
 # Cria o executável a partir dos arquivos-fonte
 add_executable(${EXECUTABLE_NAME} ${SOURCES})
 
+target_compile_features(sapphire PRIVATE cxx_std_17)
 target_compile_options(sapphire PRIVATE -g)
+target_link_libraries(sapphire PRIVATE SFML::Graphics)
+target_link_libraries(sapphire PRIVATE httplib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Versão mínima do CMake
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.25)
 
 # Nome do projeto
 project(Sapphire LANGUAGES CXX)
@@ -13,6 +13,11 @@ FetchContent_Declare(SFML
         SYSTEM)
 FetchContent_MakeAvailable(SFML)
 
+include(FetchContent)
+
+FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.12.0/json.tar.xz)
+FetchContent_MakeAvailable(json)
+
 FetchContent_Declare(httplib
         GIT_REPOSITORY https://github.com/yhirose/cpp-httplib.git
         GIT_TAG v0.29.0
@@ -21,8 +26,8 @@ FetchContent_Declare(httplib
         SYSTEM)
 FetchContent_MakeAvailable(httplib)
 
-# Define o padrão do C++ para C++17
-set(CMAKE_CXX_STANDARD 17)
+# Define o padrão do C++ para C++20
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Define o nome do executável final
@@ -31,22 +36,21 @@ set(EXECUTABLE_NAME sapphire)
 # Adiciona uma definição para ativar o código de depuração
 add_compile_definitions(DEBUG_PRINT_CODE)
 
-# Lista todxos os arquivos-fonte (.cpp) que compõem o projeto
-FILE(GLOB SOURCES src/*.cpp)
+# Lista todos os arquivos-fonte (.cpp) que compõem o projeto
 set(SOURCES
         # keep-sorted start
-        src/main.cpp
-        src/utils.cpp
         src/bytecode_io.cpp
-        src/lexer.cpp
         src/compiler.cpp
+        src/lexer.cpp
+        src/main.cpp
+        src/object.cpp
         src/parser.cpp
         src/sfml_graphics_natives.cpp
-        src/object.cpp
-        src/vm.cpp
+        src/utils.cpp
         src/value.cpp
-        src/debug.cpp # <<< ADICIONE ESTA LINHA
+        src/vm.cpp
         # keep-sorted end
+        src/debug.cpp # <<< ADICIONE ESTA LINHA
 )
 
 # Lista os diretórios onde os arquivos de cabeçalho (.h) estão
@@ -55,7 +59,11 @@ include_directories(src)
 # Cria o executável a partir dos arquivos-fonte
 add_executable(${EXECUTABLE_NAME} ${SOURCES})
 
-target_compile_features(sapphire PRIVATE cxx_std_17)
+target_compile_features(sapphire PRIVATE cxx_std_20)
 target_compile_options(sapphire PRIVATE -g)
+
+# Link 
 target_link_libraries(sapphire PRIVATE SFML::Graphics)
 target_link_libraries(sapphire PRIVATE httplib)
+target_link_libraries(sapphire PRIVATE nlohmann_json::nlohmann_json)
+

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -58,7 +58,7 @@ void print_object(const SapphireValue& value) {
 
 // Template para registrar um novo objeto no GC
 template <typename T>
-static void register_object(VM* vm, T* object) {
+void register_object(VM* vm, T* object) {
     object->is_marked = false;
     object->next = vm->objects;
     vm->objects = object;


### PR DESCRIPTION
Hey,

I've seen your post on r/brdev, and when I tried building it on my Mac it failed, so here's a patch fixing that. It also builds on Linux. To do that the following things were changed:

  - Bumped the C++ standard to C++20: some compilers are more anal re. using features from newer standards
  - Removed the `static` from the **definition** of `register_object` (as the function is declared in a header file, it made no sense to mark the definition static)
  - Bumped the required version of CMake, and added explicit dependencies on the libraries the project depends on (httplib, SFML and nlohmann_json). This way one can build the project without needing to install them system-wide