### PR TITLE
ci: deploy GitHub Pages before build tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,32 @@ on:
   pull_request:
     branches: [ "main", "master" ]
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
+  deploy-pages:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
   build:
+    needs: deploy-pages
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -15,7 +39,7 @@ jobs:
         build_type: [Release]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # Install SFML and OpenSSL from MSYS2 MINGW64 packages.
     # These are compiled with the same GCC version used to compile the project,

--- a/.github/workflows/copilot-release.yml
+++ b/.github/workflows/copilot-release.yml
@@ -19,13 +19,21 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Read release instructions
+        id: release_instructions
+        shell: bash
+        run: |
+          echo "instructions<<EOF" >> "$GITHUB_OUTPUT"
+          cat .github/release-notes-instructions.md >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
       - name: Rodar Copilot Release Notes
         id: copilot_release
         uses: github/copilot-release-notes@v1
         with:
-          from-ref: ${{ github.event.pull_request.base.sha }}
-          to-ref: ${{ github.event.pull_request.head.sha }}
-          instructions-file: .github/release-notes-instructions.md
+          base-ref: ${{ github.event.pull_request.base.sha }}
+          head-ref: ${{ github.event.pull_request.head.sha }}
+          instructions: ${{ steps.release_instructions.outputs.instructions }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Updated for GitHub Pages to deploy before build tests and fixed automatic release note generation.